### PR TITLE
Ground truth pose screwed-up coord system?

### DIFF
--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -427,10 +427,9 @@ StageNode::WorldCallback()
     // Also publish the ground truth pose and velocity
     Stg::Pose gpose = this->positionmodels[r]->GetGlobalPose();
     // Stg::Velocity gvel = this->positionmodels[r]->GetGlobalVelocity();
-    // Note that we correct for Stage's screwed-up coord system.
     tf::Quaternion q_gpose;
-    q_gpose.setRPY(0.0, 0.0, gpose.a-M_PI/2.0);
-    tf::Transform gt(q_gpose, tf::Point(gpose.y, -gpose.x, 0.0));
+    q_gpose.setRPY(0.0, 0.0, gpose.a);
+    tf::Transform gt(q_gpose, tf::Point(gpose.x, gpose.y, 0.0));
     tf::Quaternion q_gvel;
     // q_gvel.setRPY(0.0, 0.0, gvel.a-M_PI/2.0);
     // tf::Transform gv(q_gvel, tf::Point(gvel.y, -gvel.x, 0.0));


### PR DESCRIPTION
I remove the hack that claims that it fix Stage's screwed-up coord system. But in fact is that hack that makes the ground truth wrong, so I need to amend in my app.
Maybe the hack used to fix something that has been lately fixed in the underlying stagelib. Or maybe I just misunderstood the problem.... feel free to just reject this pull request in that case.
