### PR TITLE
fixed a bug on systems that cannot populate FLTK_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,18 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs nav_msgs roscpp rostest se
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 find_package(FLTK REQUIRED)
+if(FLTK_FOUND)
+  # FindFLTK.cmake doesn't populate FLTK_INCLUDE_DIRS on some systems,
+  # so we try to use FLTK_INCLUDE_DIR if we need to.
+  if("${FLTK_INCLUDE_DIRS}" STREQUAL "")
+    set(FLTK_INCLUDE_DIRS "${FLTK_INCLUDE_DIR}")
+  endif()
+  message(status "FLTK_LIBRARIES=" ${FLTK_LIBRARIES})
+  message(status "FLTK_INCLUDE_DIR=" ${FLTK_INCLUDE_DIR})
+  message(status "FLTK_INCLUDE_DIRS=" ${FLTK_INCLUDE_DIRS})
+else()
+  message(fatal_error "FLTK not found...aborting!")
+endif()
 
 set(Stage_DIR cmake)
 find_package(Stage REQUIRED)


### PR DESCRIPTION
When compiling indigo-full on Gentoo, my `FindFLTK.cmake` (cmake version 2.8.12.2) did not populate the `FLTK_INCLUDE_DIRS` variable, resulting in a compile error. This patch adds a harmless statement that will try to populate `FLTK_INCLUDE_DIRS` from `FLTK_INCLUDE_DIR` only if it is empty.

```
-- Found FLTK:
/usr/lib64/fltk-1/libfltk_images.so;/usr/lib64/fltk-1/libfltk_forms.so;/usr/lib64/fltk-1/libfltk_gl.so;/usr/lib64/libGL.so;/usr/lib64/fltk-1/libfltk.so  
-- FLTK_LIBRARIES=/usr/lib64/fltk-1/libfltk_images.so;/usr/lib64/fltk-1/libfltk_forms.so;/usr/lib64/fltk-1/libfltk_gl.so;/usr/lib64/libGL.so;/usr/lib64/fltk-1/libfltk.so;/usr/lib64/libSM.so;/usr/lib64/libICE.so;/usr/lib64/libX11.so;/usr/lib64/libXext.so;/usr/lib64/libm.so
-- FLTK_INCLUDE_DIR=/usr/include/fltk-1;/usr/include
-- FLTK_INCLUDE_DIRS=
```

```
In file included from
/home/wayne/work/ros/ros_catkin_ws/src/stage_ros/src/stageros.cpp:38:0:
/opt/ros/indigo/include/Stage-4.1/stage.hh:57:19: fatal error: FL/Fl.H: No
such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/stageros.dir/src/stageros.cpp.o] Error 1
make[1]: *** [CMakeFiles/stageros.dir/all] Error 2
make: *** [all] Error 2
<== Failed to process package 'stage_ros': 
```
