### PR TITLE
Remove runtime dependency on fltk

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,6 @@
   <build_depend>tf</build_depend>
 
   <run_depend>boost</run_depend>
-  <run_depend>fltk</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
It's a lib and will be pulled in by dh_shlibdeps automatically.

This solves a dependeny issue with libfltk1.1-dev/libfltk1.3-dev