### PR TITLE
multisensor support

### DIFF
--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -120,8 +120,6 @@ private:
     // is true, an unaltered copy of the name is returned.
     const char *mapName(const char *name, size_t robotID, Stg::Model* mod) const;
     const char *mapName(const char *name, size_t robotID, size_t deviceID, Stg::Model* mod) const;
-    const char *mapName(const char *name, size_t robotID) const;
-    const char *mapName(const char *name, size_t robotID, size_t deviceID) const;
 
     tf::TransformBroadcaster tf;
 
@@ -219,58 +217,6 @@ StageNode::mapName(const char *name, size_t robotID, size_t deviceID, Stg::Model
     }
 }
 
-const char *
-StageNode::mapName(const char *name, size_t robotID) const
-{
-    bool umn = this->use_model_names;
-
-    if ((positionmodels.size() > 1 ) || umn)
-    {
-        static char buf[100];
-        Stg::Model const* mod = static_cast<Stg::Model*>(this->robotmodels_[robotID]->positionmodel);
-        std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
-
-        if ((found==std::string::npos) && umn)
-        {
-            snprintf(buf, sizeof(buf), "/%s/%s", ((Stg::Ancestor *) mod)->Token(), name);
-        }
-        else
-        {
-            snprintf(buf, sizeof(buf), "/robot_%u/%s", (unsigned int)robotID, name);
-        }
-
-        return buf;
-    }
-    else
-        return name;
-}
-
-const char *
-StageNode::mapName(const char *name, size_t robotID, size_t deviceID) const
-{
-    bool umn = this->use_model_names;
-
-    if ((positionmodels.size() > 1 ) || umn)
-    {
-        static char buf[100];
-        Stg::Model const* mod = static_cast<Stg::Model*>(this->robotmodels_[robotID]->positionmodel);
-        std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
-
-        if ((found==std::string::npos) && umn)
-        {
-            snprintf(buf, sizeof(buf), "/%s/%s_%u", ((Stg::Ancestor *) mod)->Token(), name, (unsigned int)deviceID);
-        }
-        else
-        {
-            snprintf(buf, sizeof(buf), "/robot_%u/%s_%u", (unsigned int)robotID, name, (unsigned int)deviceID);
-        }
-
-        return buf;
-    }
-    else
-        return name;
-}
-
 void
 StageNode::ghfunc(Stg::Model* mod, StageNode* node)
 {
@@ -336,30 +282,6 @@ StageNode::StageNode(int argc, char** argv, bool gui, const char* fname, bool us
     this->world->AddUpdateCallback((Stg::world_callback_t)s_update, this);
 
     this->world->ForEachDescendant((Stg::model_callback_t)ghfunc, this);
-    /*if (lasermodels.size() > 0 && lasermodels.size() != positionmodels.size())
-    {
-        ROS_FATAL("number of position models and laser models must be equal in "
-                  "the world file.");
-        ROS_BREAK();
-    }
-    else if (cameramodels.size() > 0 && cameramodels.size() != positionmodels.size())
-    {
-        ROS_FATAL("number of position models and camera models must be equal in "
-                  "the world file.");
-        ROS_BREAK();
-    }
-    size_t numRobots = positionmodels.size();
-    ROS_INFO("found %u position and laser(%u)/camera(%u) pair%s in the file",
-             (unsigned int)numRobots, (unsigned int) lasermodels.size(), (unsigned int) cameramodels.size(), (numRobots==1) ? "" : "s");
-*/
-    /*
-    this->laserMsgs = new sensor_msgs::LaserScan[numRobots];
-    this->odomMsgs = new nav_msgs::Odometry[numRobots];
-    this->groundTruthMsgs = new nav_msgs::Odometry[numRobots];
-    this->imageMsgs = new sensor_msgs::Image[numRobots];
-    this->depthMsgs = new sensor_msgs::Image[numRobots];
-    this->cameraMsgs = new sensor_msgs::CameraInfo[numRobots];
-    */
 }
 
 
@@ -533,7 +455,6 @@ StageNode::WorldCallback()
         }
 
         //the position of the robot
-        //tf::Transform txIdentity(tf::createIdentityQuaternion(), tf::Point(0, 0, 0));
         tf.sendTransform(tf::StampedTransform(tf::Transform::getIdentity(),
                                               sim_time,
                                               mapName("base_footprint", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -63,15 +63,7 @@
 // Our node
 class StageNode
 {
-  private:
-    // Messages that we'll send or receive
-    sensor_msgs::CameraInfo *cameraMsgs;
-    sensor_msgs::Image *imageMsgs;
-    sensor_msgs::Image *depthMsgs;
-    sensor_msgs::LaserScan *laserMsgs;
-    nav_msgs::Odometry *odomMsgs;
-    nav_msgs::Odometry *groundTruthMsgs;
-    rosgraph_msgs::Clock clockMsg;
+private:
 
     // roscpp-related bookkeeping
     ros::NodeHandle n_;
@@ -83,13 +75,30 @@ class StageNode
     std::vector<Stg::ModelCamera *> cameramodels;
     std::vector<Stg::ModelRanger *> lasermodels;
     std::vector<Stg::ModelPosition *> positionmodels;
-    std::vector<ros::Publisher> image_pubs_;
-    std::vector<ros::Publisher> depth_pubs_;
-    std::vector<ros::Publisher> camera_pubs_;
-    std::vector<ros::Publisher> laser_pubs_;
-    std::vector<ros::Publisher> odom_pubs_;
-    std::vector<ros::Publisher> ground_truth_pubs_;
-    std::vector<ros::Subscriber> cmdvel_subs_;
+
+    //a structure representing a robot inthe simulator
+    struct StageRobot
+    {
+        //stage related models
+        Stg::ModelPosition* positionmodel; //one position
+        std::vector<Stg::ModelCamera *> cameramodels; //multiple cameras per position
+        std::vector<Stg::ModelRanger *> lasermodels; //multiple rangers per position
+
+        //ros publishers
+        ros::Publisher odom_pub; //one odom
+        ros::Publisher ground_truth_pub; //one ground truth
+
+        std::vector<ros::Publisher> image_pubs; //multiple images
+        std::vector<ros::Publisher> depth_pubs; //multiple depths
+        std::vector<ros::Publisher> camera_pubs; //multiple cameras
+        std::vector<ros::Publisher> laser_pubs; //multiple lasers
+
+        ros::Subscriber cmdvel_sub; //one cmd_vel subscriber
+    };
+
+    std::vector<StageRobot const *> robotmodels_;
+
+
     ros::Publisher clock_pub_;
     
     bool isDepthCanonical;
@@ -101,15 +110,18 @@ class StageNode
 
     static bool s_update(Stg::World* world, StageNode* node)
     {
-      node->WorldCallback();
-      // We return false to indicate that we want to be called again (an
-      // odd convention, but that's the way that Stage works).
-      return false;
+        node->WorldCallback();
+        // We return false to indicate that we want to be called again (an
+        // odd convention, but that's the way that Stage works).
+        return false;
     }
 
     // Appends the given robot ID to the given message name.  If omitRobotID
-    // is true, an unaltered copy of the name is returned.    
-    const char *mapName(const char *name, size_t robotID, Stg::Model* mod);
+    // is true, an unaltered copy of the name is returned.
+    const char *mapName(const char *name, size_t robotID, Stg::Model* mod) const;
+    const char *mapName(const char *name, size_t robotID, size_t deviceID, Stg::Model* mod) const;
+    const char *mapName(const char *name, size_t robotID) const;
+    const char *mapName(const char *name, size_t robotID, size_t deviceID) const;
 
     tf::TransformBroadcaster tf;
 
@@ -125,7 +137,7 @@ class StageNode
     // Last published global pose of each robot
     std::vector<Stg::Pose> base_last_globalpos;
 
-  public:
+public:
     // Constructor; stage itself needs argc/argv.  fname is the .world file
     // that stage should load.
     StageNode(int argc, char** argv, bool gui, const char* fname, bool use_model_names);
@@ -152,117 +164,202 @@ class StageNode
 
 // since stageros is single-threaded, this is OK. revisit if that changes!
 const char *
-StageNode::mapName(const char *name, size_t robotID, Stg::Model* mod)
+StageNode::mapName(const char *name, size_t robotID, Stg::Model* mod) const
 {
-	bool umn = this->use_model_names;
-	
-  if ((positionmodels.size() > 1 ) || umn)
-  {
-    static char buf[100];
-    std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
-    
-    if ((found==std::string::npos) && umn)
+    //ROS_INFO("Robot %lu: Device %s", robotID, name);
+    bool umn = this->use_model_names;
+
+    if ((positionmodels.size() > 1 ) || umn)
     {
-    	snprintf(buf, sizeof(buf), "/%s/%s", ((Stg::Ancestor *) mod)->Token(), name);
+        static char buf[100];
+        std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
+
+        if ((found==std::string::npos) && umn)
+        {
+            snprintf(buf, sizeof(buf), "/%s/%s", ((Stg::Ancestor *) mod)->Token(), name);
+        }
+        else
+        {
+            snprintf(buf, sizeof(buf), "/robot_%u/%s", (unsigned int)robotID, name);
+        }
+
+        return buf;
+    }
+    else
+        return name;
+}
+
+const char *
+StageNode::mapName(const char *name, size_t robotID, size_t deviceID, Stg::Model* mod) const
+{
+    //ROS_INFO("Robot %lu: Device %s:%lu", robotID, name, deviceID);
+    bool umn = this->use_model_names;
+
+    if ((positionmodels.size() > 1 ) || umn)
+    {
+        static char buf[100];
+        std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
+
+        if ((found==std::string::npos) && umn)
+        {
+            snprintf(buf, sizeof(buf), "/%s/%s_%u", ((Stg::Ancestor *) mod)->Token(), name, (unsigned int)deviceID);
+        }
+        else
+        {
+            snprintf(buf, sizeof(buf), "/robot_%u/%s_%u", (unsigned int)robotID, name, (unsigned int)deviceID);
+        }
+
+        return buf;
     }
     else
     {
- 	snprintf(buf, sizeof(buf), "/robot_%u/%s", (unsigned int)robotID, name);
+        static char buf[100];
+        snprintf(buf, sizeof(buf), "/%s_%u", name, (unsigned int)deviceID);
+        return buf;
     }
+}
 
-    return buf;
-  }
-  else
-    return name;
+const char *
+StageNode::mapName(const char *name, size_t robotID) const
+{
+    bool umn = this->use_model_names;
+
+    if ((positionmodels.size() > 1 ) || umn)
+    {
+        static char buf[100];
+        Stg::Model const* mod = static_cast<Stg::Model*>(this->robotmodels_[robotID]->positionmodel);
+        std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
+
+        if ((found==std::string::npos) && umn)
+        {
+            snprintf(buf, sizeof(buf), "/%s/%s", ((Stg::Ancestor *) mod)->Token(), name);
+        }
+        else
+        {
+            snprintf(buf, sizeof(buf), "/robot_%u/%s", (unsigned int)robotID, name);
+        }
+
+        return buf;
+    }
+    else
+        return name;
+}
+
+const char *
+StageNode::mapName(const char *name, size_t robotID, size_t deviceID) const
+{
+    bool umn = this->use_model_names;
+
+    if ((positionmodels.size() > 1 ) || umn)
+    {
+        static char buf[100];
+        Stg::Model const* mod = static_cast<Stg::Model*>(this->robotmodels_[robotID]->positionmodel);
+        std::size_t found = std::string(((Stg::Ancestor *) mod)->Token()).find(":");
+
+        if ((found==std::string::npos) && umn)
+        {
+            snprintf(buf, sizeof(buf), "/%s/%s_%u", ((Stg::Ancestor *) mod)->Token(), name, (unsigned int)deviceID);
+        }
+        else
+        {
+            snprintf(buf, sizeof(buf), "/robot_%u/%s_%u", (unsigned int)robotID, name, (unsigned int)deviceID);
+        }
+
+        return buf;
+    }
+    else
+        return name;
 }
 
 void
 StageNode::ghfunc(Stg::Model* mod, StageNode* node)
 {
-  if (dynamic_cast<Stg::ModelRanger *>(mod))
-    node->lasermodels.push_back(dynamic_cast<Stg::ModelRanger *>(mod));
-  if (dynamic_cast<Stg::ModelPosition *>(mod))
-    node->positionmodels.push_back(dynamic_cast<Stg::ModelPosition *>(mod));
-  if (dynamic_cast<Stg::ModelCamera *>(mod))
-    node->cameramodels.push_back(dynamic_cast<Stg::ModelCamera *>(mod));
+    if (dynamic_cast<Stg::ModelRanger *>(mod))
+        node->lasermodels.push_back(dynamic_cast<Stg::ModelRanger *>(mod));
+    if (dynamic_cast<Stg::ModelPosition *>(mod))
+        node->positionmodels.push_back(dynamic_cast<Stg::ModelPosition *>(mod));
+    if (dynamic_cast<Stg::ModelCamera *>(mod))
+        node->cameramodels.push_back(dynamic_cast<Stg::ModelCamera *>(mod));
 }
 
 void
 StageNode::cmdvelReceived(int idx, const boost::shared_ptr<geometry_msgs::Twist const>& msg)
 {
-  boost::mutex::scoped_lock lock(msg_lock);
-  this->positionmodels[idx]->SetSpeed(msg->linear.x, 
-                                      msg->linear.y, 
-                                      msg->angular.z);
-  this->base_last_cmd = this->sim_time;
+    boost::mutex::scoped_lock lock(msg_lock);
+    this->positionmodels[idx]->SetSpeed(msg->linear.x,
+                                        msg->linear.y,
+                                        msg->angular.z);
+    this->base_last_cmd = this->sim_time;
 }
 
 StageNode::StageNode(int argc, char** argv, bool gui, const char* fname, bool use_model_names)
 {
-  this->use_model_names = use_model_names;
-  this->sim_time.fromSec(0.0);
-  this->base_last_cmd.fromSec(0.0);
-  double t;
-  ros::NodeHandle localn("~");
-  if(!localn.getParam("base_watchdog_timeout", t))
-    t = 0.2;
-  this->base_watchdog_timeout.fromSec(t);
-  
-  if(!localn.getParam("is_depth_canonical", isDepthCanonical))
-    isDepthCanonical = true;
-  
+    this->use_model_names = use_model_names;
+    this->sim_time.fromSec(0.0);
+    this->base_last_cmd.fromSec(0.0);
+    double t;
+    ros::NodeHandle localn("~");
+    if(!localn.getParam("base_watchdog_timeout", t))
+        t = 0.2;
+    this->base_watchdog_timeout.fromSec(t);
 
-  // We'll check the existence of the world file, because libstage doesn't
-  // expose its failure to open it.  Could go further with checks (e.g., is
-  // it readable by this user).
-  struct stat s;
-  if(stat(fname, &s) != 0)
-  {
-    ROS_FATAL("The world file %s does not exist.", fname);
-    ROS_BREAK();
-  }
+    if(!localn.getParam("is_depth_canonical", isDepthCanonical))
+        isDepthCanonical = true;
 
-  // initialize libstage
-  Stg::Init( &argc, &argv );
 
-  if(gui)
-    this->world = new Stg::WorldGui(600, 400, "Stage (ROS)");
-  else
-    this->world = new Stg::World();
+    // We'll check the existence of the world file, because libstage doesn't
+    // expose its failure to open it.  Could go further with checks (e.g., is
+    // it readable by this user).
+    struct stat s;
+    if(stat(fname, &s) != 0)
+    {
+        ROS_FATAL("The world file %s does not exist.", fname);
+        ROS_BREAK();
+    }
 
-  // Apparently an Update is needed before the Load to avoid crashes on
-  // startup on some systems.
-  // As of Stage 4.1.1, this update call causes a hang on start.
-  //this->UpdateWorld();
-  this->world->Load(fname);
+    // initialize libstage
+    Stg::Init( &argc, &argv );
 
-  // We add our callback here, after the Update, so avoid our callback
-  // being invoked before we're ready.
-  this->world->AddUpdateCallback((Stg::world_callback_t)s_update, this);
+    if(gui)
+        this->world = new Stg::WorldGui(600, 400, "Stage (ROS)");
+    else
+        this->world = new Stg::World();
 
-  this->world->ForEachDescendant((Stg::model_callback_t)ghfunc, this);
-  if (lasermodels.size() > 0 && lasermodels.size() != positionmodels.size())
-  {
-    ROS_FATAL("number of position models and laser models must be equal in "
-              "the world file.");
-    ROS_BREAK();
-  }
-  else if (cameramodels.size() > 0 && cameramodels.size() != positionmodels.size())
-  {
-    ROS_FATAL("number of position models and camera models must be equal in "
-              "the world file.");
-    ROS_BREAK();
-  }
-  size_t numRobots = positionmodels.size();
-  ROS_INFO("found %u position and laser(%u)/camera(%u) pair%s in the file", 
-           (unsigned int)numRobots, (unsigned int) lasermodels.size(), (unsigned int) cameramodels.size(), (numRobots==1) ? "" : "s");
+    // Apparently an Update is needed before the Load to avoid crashes on
+    // startup on some systems.
+    // As of Stage 4.1.1, this update call causes a hang on start.
+    //this->UpdateWorld();
+    this->world->Load(fname);
 
-  this->laserMsgs = new sensor_msgs::LaserScan[numRobots];
-  this->odomMsgs = new nav_msgs::Odometry[numRobots];
-  this->groundTruthMsgs = new nav_msgs::Odometry[numRobots];
-  this->imageMsgs = new sensor_msgs::Image[numRobots];
-  this->depthMsgs = new sensor_msgs::Image[numRobots];
-  this->cameraMsgs = new sensor_msgs::CameraInfo[numRobots];
+    // We add our callback here, after the Update, so avoid our callback
+    // being invoked before we're ready.
+    this->world->AddUpdateCallback((Stg::world_callback_t)s_update, this);
+
+    this->world->ForEachDescendant((Stg::model_callback_t)ghfunc, this);
+    /*if (lasermodels.size() > 0 && lasermodels.size() != positionmodels.size())
+    {
+        ROS_FATAL("number of position models and laser models must be equal in "
+                  "the world file.");
+        ROS_BREAK();
+    }
+    else if (cameramodels.size() > 0 && cameramodels.size() != positionmodels.size())
+    {
+        ROS_FATAL("number of position models and camera models must be equal in "
+                  "the world file.");
+        ROS_BREAK();
+    }
+    size_t numRobots = positionmodels.size();
+    ROS_INFO("found %u position and laser(%u)/camera(%u) pair%s in the file",
+             (unsigned int)numRobots, (unsigned int) lasermodels.size(), (unsigned int) cameramodels.size(), (numRobots==1) ? "" : "s");
+*/
+    /*
+    this->laserMsgs = new sensor_msgs::LaserScan[numRobots];
+    this->odomMsgs = new nav_msgs::Odometry[numRobots];
+    this->groundTruthMsgs = new nav_msgs::Odometry[numRobots];
+    this->imageMsgs = new sensor_msgs::Image[numRobots];
+    this->depthMsgs = new sensor_msgs::Image[numRobots];
+    this->cameraMsgs = new sensor_msgs::CameraInfo[numRobots];
+    */
 }
 
 
@@ -275,408 +372,458 @@ StageNode::StageNode(int argc, char** argv, bool gui, const char* fname, bool us
 int
 StageNode::SubscribeModels()
 {
-  n_.setParam("/use_sim_time", true);
+    n_.setParam("/use_sim_time", true);
 
-  for (size_t r = 0; r < this->positionmodels.size(); r++)
-  {
-    if(this->lasermodels.size()>r && this->lasermodels[r])
+    for (size_t r = 0; r < this->positionmodels.size(); r++)
     {
-      this->lasermodels[r]->Subscribe();
+        StageRobot* new_robot = new StageRobot;
+        new_robot->positionmodel = this->positionmodels[r];
+        new_robot->positionmodel->Subscribe();
+
+
+        for (size_t s = 0; s < this->lasermodels.size(); s++)
+        {
+            if (this->lasermodels[s] and this->lasermodels[s]->Parent() == new_robot->positionmodel)
+            {
+                new_robot->lasermodels.push_back(this->lasermodels[s]);
+                this->lasermodels[s]->Subscribe();
+            }
+        }
+
+        for (size_t s = 0; s < this->cameramodels.size(); s++)
+        {
+            if (this->cameramodels[s] and this->cameramodels[s]->Parent() == new_robot->positionmodel)
+            {
+                new_robot->cameramodels.push_back(this->cameramodels[s]);
+                this->cameramodels[s]->Subscribe();
+            }
+        }
+
+        ROS_INFO("Found %lu laser devices and %lu cameras in robot %lu", new_robot->lasermodels.size(), new_robot->cameramodels.size(), r);
+
+        new_robot->odom_pub = n_.advertise<nav_msgs::Odometry>(mapName(ODOM, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10);
+        new_robot->ground_truth_pub = n_.advertise<nav_msgs::Odometry>(mapName(BASE_POSE_GROUND_TRUTH, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10);
+        new_robot->cmdvel_sub = n_.subscribe<geometry_msgs::Twist>(mapName(CMD_VEL, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, boost::bind(&StageNode::cmdvelReceived, this, r, _1));
+
+        for (size_t s = 0;  s < new_robot->lasermodels.size(); ++s)
+        {
+            if (new_robot->lasermodels.size() == 1)
+                new_robot->laser_pubs.push_back(n_.advertise<sensor_msgs::LaserScan>(mapName(BASE_SCAN, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+            else
+                new_robot->laser_pubs.push_back(n_.advertise<sensor_msgs::LaserScan>(mapName(BASE_SCAN, r, s, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+
+        }
+
+        for (size_t s = 0;  s < new_robot->cameramodels.size(); ++s)
+        {
+            if (new_robot->cameramodels.size() == 1)
+            {
+                new_robot->image_pubs.push_back(n_.advertise<sensor_msgs::Image>(mapName(IMAGE, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+                new_robot->depth_pubs.push_back(n_.advertise<sensor_msgs::Image>(mapName(DEPTH, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+                new_robot->camera_pubs.push_back(n_.advertise<sensor_msgs::CameraInfo>(mapName(CAMERA_INFO, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+            }
+            else
+            {
+                new_robot->image_pubs.push_back(n_.advertise<sensor_msgs::Image>(mapName(IMAGE, r, s, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+                new_robot->depth_pubs.push_back(n_.advertise<sensor_msgs::Image>(mapName(DEPTH, r, s, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+                new_robot->camera_pubs.push_back(n_.advertise<sensor_msgs::CameraInfo>(mapName(CAMERA_INFO, r, s, static_cast<Stg::Model*>(new_robot->positionmodel)), 10));
+            }
+        }
+
+        this->robotmodels_.push_back(new_robot);
     }
-    else if (this->lasermodels.size()>0)
-    {
-      ROS_ERROR("no laser");
-      return(-1);
-    }
-    if(this->positionmodels[r])
-    {
-      this->positionmodels[r]->Subscribe();
-    }
-    else
-    {
-      ROS_ERROR("no position");
-      return(-1);
-    }
-    if(this->cameramodels.size()>r && this->cameramodels[r])
-    {
-      this->cameramodels[r]->Subscribe();
-    }
-    else if (this->cameramodels.size()>0)
-    {
-      ROS_ERROR_STREAM("no camera " << this->cameramodels.size());
-      return(-1);
-    }
-    if (this->lasermodels.size()>r)
-      laser_pubs_.push_back(n_.advertise<sensor_msgs::LaserScan>(mapName(BASE_SCAN,r,static_cast<Stg::Model*>(positionmodels[r])), 10));
-    odom_pubs_.push_back(n_.advertise<nav_msgs::Odometry>(mapName(ODOM,r,static_cast<Stg::Model*>(positionmodels[r])), 10));
-    ground_truth_pubs_.push_back(n_.advertise<nav_msgs::Odometry>(mapName(BASE_POSE_GROUND_TRUTH,r,static_cast<Stg::Model*>(positionmodels[r])), 10));
-    if (this->cameramodels.size()>r){
-      image_pubs_.push_back(n_.advertise<sensor_msgs::Image>(mapName(IMAGE,r,static_cast<Stg::Model*>(positionmodels[r])), 10));
-      depth_pubs_.push_back(n_.advertise<sensor_msgs::Image>(mapName(DEPTH,r,static_cast<Stg::Model*>(positionmodels[r])), 10));
-      camera_pubs_.push_back(n_.advertise<sensor_msgs::CameraInfo>(mapName(CAMERA_INFO,r,static_cast<Stg::Model*>(positionmodels[r])), 10));
-    }
-    cmdvel_subs_.push_back(n_.subscribe<geometry_msgs::Twist>(mapName(CMD_VEL,r,static_cast<Stg::Model*>(positionmodels[r])), 10, boost::bind(&StageNode::cmdvelReceived, this, r, _1)));
-  }
-  clock_pub_ = n_.advertise<rosgraph_msgs::Clock>("/clock",10);
-  return(0);
+    clock_pub_ = n_.advertise<rosgraph_msgs::Clock>("/clock", 10);
+    return(0);
 }
 
 StageNode::~StageNode()
-{
-  delete[] laserMsgs;
-  delete[] odomMsgs;
-  delete[] groundTruthMsgs;
-  delete[] imageMsgs;
-  delete[] depthMsgs;
-  delete[] cameraMsgs;
+{    
+    for (std::vector<StageRobot const*>::iterator r = this->robotmodels_.begin(); r != this->robotmodels_.end(); ++r)
+        delete *r;
 }
 
 bool
 StageNode::UpdateWorld()
 {
-  return this->world->UpdateAll();
+    return this->world->UpdateAll();
 }
 
 void
 StageNode::WorldCallback()
 {
-  boost::mutex::scoped_lock lock(msg_lock);
+    boost::mutex::scoped_lock lock(msg_lock);
 
-  this->sim_time.fromSec(world->SimTimeNow() / 1e6);
-  // We're not allowed to publish clock==0, because it used as a special
-  // value in parts of ROS, #4027.
-  if(this->sim_time.sec == 0 && this->sim_time.nsec == 0)
-  {
-    ROS_DEBUG("Skipping initial simulation step, to avoid publishing clock==0");
-    return;
-  }
-
-  // TODO make this only affect one robot if necessary
-  if((this->base_watchdog_timeout.toSec() > 0.0) &&
-      ((this->sim_time - this->base_last_cmd) >= this->base_watchdog_timeout))
-  {
-    for (size_t r = 0; r < this->positionmodels.size(); r++)
-      this->positionmodels[r]->SetSpeed(0.0, 0.0, 0.0);
-  }
-
-  // Get latest laser data
-  for (size_t r = 0; r < this->lasermodels.size(); r++)
-		{
-			const std::vector<Stg::ModelRanger::Sensor>& sensors = this->lasermodels[r]->GetSensors();
-		
-		if( sensors.size() > 1 )
-			ROS_WARN( "ROS Stage currently supports rangers with 1 sensor only." );
-
-		// for now we access only the zeroth sensor of the ranger - good
-		// enough for most laser models that have a single beam origin
-		const Stg::ModelRanger::Sensor& s = sensors[0];
-		
-    if( s.ranges.size() )
-			{
-      // Translate into ROS message format and publish
-      this->laserMsgs[r].angle_min = -s.fov/2.0;
-      this->laserMsgs[r].angle_max = +s.fov/2.0;
-      this->laserMsgs[r].angle_increment = s.fov/(double)(s.sample_count-1);
-      this->laserMsgs[r].range_min = s.range.min;
-      this->laserMsgs[r].range_max = s.range.max;
-      this->laserMsgs[r].ranges.resize(s.ranges.size());
-      this->laserMsgs[r].intensities.resize(s.intensities.size());
-			
-      for(unsigned int i=0; i<s.ranges.size(); i++)
-				{
-					this->laserMsgs[r].ranges[i] = s.ranges[i];
-					this->laserMsgs[r].intensities[i] = (uint8_t)s.intensities[i];
-				}
-			
-      this->laserMsgs[r].header.frame_id = mapName("base_laser_link", r,static_cast<Stg::Model*>(positionmodels[r]));
-      this->laserMsgs[r].header.stamp = sim_time;
-      this->laser_pubs_[r].publish(this->laserMsgs[r]);
-			}
-
-    // Also publish the base->base_laser_link Tx.  This could eventually move
-    // into being retrieved from the param server as a static Tx.
-    Stg::Pose lp = this->lasermodels[r]->GetPose();
-    tf::Quaternion laserQ;
-    laserQ.setRPY(0.0, 0.0, lp.a);
-    tf::Transform txLaser =  tf::Transform(laserQ,
-                                            tf::Point(lp.x, lp.y, this->positionmodels[r]->GetGeom().size.z+lp.z));
-    tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
-                                          mapName("base_link", r,static_cast<Stg::Model*>(positionmodels[r])),
-                                          mapName("base_laser_link", r,static_cast<Stg::Model*>(positionmodels[r]))));
-    }
-    
-    for (size_t r = 0; r < this->positionmodels.size(); r++)
-		{
-    // Send the identity transform between base_footprint and base_link
-    tf::Transform txIdentity(tf::createIdentityQuaternion(),
-                             tf::Point(0, 0, 0));
-    tf.sendTransform(tf::StampedTransform(txIdentity,
-                                          sim_time,
-                                          mapName("base_footprint", r,static_cast<Stg::Model*>(positionmodels[r])),
-                                          mapName("base_link", r,static_cast<Stg::Model*>(positionmodels[r]))));
-
-    // Get latest odometry data
-    // Translate into ROS message format and publish
-    this->odomMsgs[r].pose.pose.position.x = this->positionmodels[r]->est_pose.x;
-    this->odomMsgs[r].pose.pose.position.y = this->positionmodels[r]->est_pose.y;
-    this->odomMsgs[r].pose.pose.orientation = tf::createQuaternionMsgFromYaw(this->positionmodels[r]->est_pose.a);
-    Stg::Velocity v = this->positionmodels[r]->GetVelocity();
-    this->odomMsgs[r].twist.twist.linear.x = v.x;
-    this->odomMsgs[r].twist.twist.linear.y = v.y;
-    this->odomMsgs[r].twist.twist.angular.z = v.a;
-
-    //@todo Publish stall on a separate topic when one becomes available
-    //this->odomMsgs[r].stall = this->positionmodels[r]->Stall();
-    //
-    this->odomMsgs[r].header.frame_id = mapName("odom", r,static_cast<Stg::Model*>(positionmodels[r]));
-    this->odomMsgs[r].header.stamp = sim_time;
-
-    this->odom_pubs_[r].publish(this->odomMsgs[r]);
-
-    // broadcast odometry transform
-    tf::Quaternion odomQ;
-    tf::quaternionMsgToTF(odomMsgs[r].pose.pose.orientation, odomQ);
-    tf::Transform txOdom(odomQ, 
-                         tf::Point(odomMsgs[r].pose.pose.position.x,
-                                   odomMsgs[r].pose.pose.position.y, 0.0));
-    tf.sendTransform(tf::StampedTransform(txOdom, sim_time,
-                                          mapName("odom", r,static_cast<Stg::Model*>(positionmodels[r])),
-                                          mapName("base_footprint", r,static_cast<Stg::Model*>(positionmodels[r]))));
-
-    // Also publish the ground truth pose and velocity
-    Stg::Pose gpose = this->positionmodels[r]->GetGlobalPose();
-    tf::Quaternion q_gpose;
-    q_gpose.setRPY(0.0, 0.0, gpose.a);
-    tf::Transform gt(q_gpose, tf::Point(gpose.x, gpose.y, 0.0));
-    // Velocity is 0 by default and will be set only if there is previous pose and time delta>0
-    Stg::Velocity gvel(0,0,0,0);
-    if (this->base_last_globalpos.size()>r){
-      Stg::Pose prevpose = this->base_last_globalpos.at(r);
-      double dT = (this->sim_time-this->base_last_globalpos_time).toSec();
-      if (dT>0)
-        gvel = Stg::Velocity(
-          (gpose.x - prevpose.x)/dT, 
-          (gpose.y - prevpose.y)/dT, 
-          (gpose.z - prevpose.z)/dT, 
-          Stg::normalize(gpose.a - prevpose.a)/dT
-        );
-      this->base_last_globalpos.at(r) = gpose;
-    }else //There are no previous readings, adding current pose...
-      this->base_last_globalpos.push_back(gpose);
-
-    this->groundTruthMsgs[r].pose.pose.position.x     = gt.getOrigin().x();
-    this->groundTruthMsgs[r].pose.pose.position.y     = gt.getOrigin().y();
-    this->groundTruthMsgs[r].pose.pose.position.z     = gt.getOrigin().z();
-    this->groundTruthMsgs[r].pose.pose.orientation.x  = gt.getRotation().x();
-    this->groundTruthMsgs[r].pose.pose.orientation.y  = gt.getRotation().y();
-    this->groundTruthMsgs[r].pose.pose.orientation.z  = gt.getRotation().z();
-    this->groundTruthMsgs[r].pose.pose.orientation.w  = gt.getRotation().w();
-    this->groundTruthMsgs[r].twist.twist.linear.x = gvel.x;
-    this->groundTruthMsgs[r].twist.twist.linear.y = gvel.y;
-    this->groundTruthMsgs[r].twist.twist.linear.z = gvel.z;
-    this->groundTruthMsgs[r].twist.twist.angular.z = gvel.a;
-
-    this->groundTruthMsgs[r].header.frame_id = mapName("odom", r,static_cast<Stg::Model*>(positionmodels[r]));
-    this->groundTruthMsgs[r].header.stamp = sim_time;
-
-    this->ground_truth_pubs_[r].publish(this->groundTruthMsgs[r]);
-  }
-  
-  this->base_last_globalpos_time = this->sim_time;
-  
-  for (size_t r = 0; r < this->cameramodels.size(); r++)
-  {
-    // Get latest image data
-    // Translate into ROS message format and publish
-    if (this->image_pubs_[r].getNumSubscribers()>0 && this->cameramodels[r]->FrameColor()) {
-       this->imageMsgs[r].height=this->cameramodels[r]->getHeight();
-       this->imageMsgs[r].width=this->cameramodels[r]->getWidth();
-       this->imageMsgs[r].encoding="rgba8";
-       //this->imageMsgs[r].is_bigendian="";
-       this->imageMsgs[r].step=this->imageMsgs[r].width*4;
-       this->imageMsgs[r].data.resize(this->imageMsgs[r].width*this->imageMsgs[r].height*4);
-
-       memcpy(&(this->imageMsgs[r].data[0]),this->cameramodels[r]->FrameColor(),this->imageMsgs[r].width*this->imageMsgs[r].height*4);
-
-       //invert the opengl weirdness
-       int height = this->imageMsgs[r].height - 1;
-       int linewidth = this->imageMsgs[r].width*4;
-
-       char* temp = new char[linewidth];
-       for (int y = 0; y < (height+1)/2; y++) 
-       {
-            memcpy(temp,&this->imageMsgs[r].data[y*linewidth],linewidth);
-            memcpy(&(this->imageMsgs[r].data[y*linewidth]),&(this->imageMsgs[r].data[(height-y)*linewidth]),linewidth);
-            memcpy(&(this->imageMsgs[r].data[(height-y)*linewidth]),temp,linewidth);
-       }
-
-        this->imageMsgs[r].header.frame_id = mapName("camera", r,static_cast<Stg::Model*>(positionmodels[r]));
-        this->imageMsgs[r].header.stamp = sim_time;
-
-        this->image_pubs_[r].publish(this->imageMsgs[r]);      
-    }
-    //Get latest depth data
-    //Translate into ROS message format and publish
-    //Skip if there are no subscribers
-    if (this->depth_pubs_[r].getNumSubscribers()>0 && this->cameramodels[r]->FrameDepth()) {
-      this->depthMsgs[r].height=this->cameramodels[r]->getHeight();
-      this->depthMsgs[r].width=this->cameramodels[r]->getWidth();
-      this->depthMsgs[r].encoding=this->isDepthCanonical?sensor_msgs::image_encodings::TYPE_32FC1:sensor_msgs::image_encodings::TYPE_16UC1;
-      //this->depthMsgs[r].is_bigendian="";
-      int sz = this->isDepthCanonical?sizeof(float):sizeof(uint16_t);
-      size_t len = this->depthMsgs[r].width*this->depthMsgs[r].height;
-      this->depthMsgs[r].step=this->depthMsgs[r].width*sz;
-      this->depthMsgs[r].data.resize(len*sz);
-
-      //processing data according to REP118
-      if (this->isDepthCanonical){
-        double nearClip = this->cameramodels[r]->getCamera().nearClip();
-        double farClip = this->cameramodels[r]->getCamera().farClip();
-        memcpy(&(this->depthMsgs[r].data[0]),this->cameramodels[r]->FrameDepth(),len*sz);
-        float * data = (float*)&(this->depthMsgs[r].data[0]);
-        for (size_t i=0;i<len;++i)
-          if(data[i]<=nearClip) 
-            data[i] = -INFINITY;
-          else if(data[i]>=farClip) 
-            data[i] = INFINITY;
-      }
-      else{
-        int nearClip = (int)(this->cameramodels[r]->getCamera().nearClip() * 1000);
-        int farClip = (int)(this->cameramodels[r]->getCamera().farClip() * 1000);
-        for (size_t i=0;i<len;++i){
-          int v = (int)(this->cameramodels[r]->FrameDepth()[i]*1000);
-          if (v<=nearClip || v>=farClip) v = 0;
-          ((uint16_t*)&(this->depthMsgs[r].data[0]))[i] = (uint16_t) ((v<=nearClip || v>=farClip) ? 0 : v );
-        }
-      }
-      
-      //invert the opengl weirdness
-      int height = this->depthMsgs[r].height - 1;
-      int linewidth = this->depthMsgs[r].width*sz;
-
-      char* temp = new char[linewidth];
-      for (int y = 0; y < (height+1)/2; y++) 
-      {
-           memcpy(temp,&this->depthMsgs[r].data[y*linewidth],linewidth);
-           memcpy(&(this->depthMsgs[r].data[y*linewidth]),&(this->depthMsgs[r].data[(height-y)*linewidth]),linewidth);
-           memcpy(&(this->depthMsgs[r].data[(height-y)*linewidth]),temp,linewidth);
-      }
-
-      this->depthMsgs[r].header.frame_id = mapName("camera", r,static_cast<Stg::Model*>(positionmodels[r]));
-      this->depthMsgs[r].header.stamp = sim_time;
-      this->depth_pubs_[r].publish(this->depthMsgs[r]);
-    }
-    
-    //sending camera's tf and info only if image or depth topics are subscribed to
-    if ((this->image_pubs_[r].getNumSubscribers()>0 && this->cameramodels[r]->FrameColor())
-    || (this->depth_pubs_[r].getNumSubscribers()>0 && this->cameramodels[r]->FrameDepth()))
+    this->sim_time.fromSec(world->SimTimeNow() / 1e6);
+    // We're not allowed to publish clock==0, because it used as a special
+    // value in parts of ROS, #4027.
+    if(this->sim_time.sec == 0 && this->sim_time.nsec == 0)
     {
-       
-      Stg::Pose lp = this->cameramodels[r]->GetPose();
-      tf::Quaternion Q; Q.setRPY(
-        (this->cameramodels[r]->getCamera().pitch()*M_PI/180.0)-M_PI, 
-        0.0, 
-        lp.a+(this->cameramodels[r]->getCamera().yaw()*M_PI/180.0)-this->positionmodels[r]->GetPose().a
-        );
-        
-      tf::Transform tr =  tf::Transform(Q, tf::Point(lp.x, lp.y, this->positionmodels[r]->GetGeom().size.z+lp.z));
-      tf.sendTransform(tf::StampedTransform(tr, sim_time,
-                                          mapName("base_link", r,static_cast<Stg::Model*>(positionmodels[r])),
-                                          mapName("camera", r,static_cast<Stg::Model*>(positionmodels[r]))));
-      
-      this->cameraMsgs[r].header.frame_id = mapName("camera", r,static_cast<Stg::Model*>(positionmodels[r]));
-      this->cameraMsgs[r].header.stamp = sim_time;
-      this->cameraMsgs[r].height = this->cameramodels[r]->getHeight();
-      this->cameraMsgs[r].width = this->cameramodels[r]->getWidth();
-      
-      double fx,fy,cx,cy;
-      cx = this->cameraMsgs[r].width / 2.0;
-      cy = this->cameraMsgs[r].height / 2.0;
-      double fovh = this->cameramodels[r]->getCamera().horizFov()*M_PI/180.0;
-      double fovv = this->cameramodels[r]->getCamera().vertFov()*M_PI/180.0;
-      //double fx_ = 1.43266615300557*this->cameramodels[r]->getWidth()/tan(fovh);
-      //double fy_ = 1.43266615300557*this->cameramodels[r]->getHeight()/tan(fovv);
-      fx = this->cameramodels[r]->getWidth()/(2*tan(fovh/2));
-      fy = this->cameramodels[r]->getHeight()/(2*tan(fovv/2));
-      
-      //ROS_INFO("fx=%.4f,%.4f; fy=%.4f,%.4f", fx, fx_, fy, fy_);
- 
-      
-      this->cameraMsgs[r].D.resize(4, 0.0);
+        ROS_DEBUG("Skipping initial simulation step, to avoid publishing clock==0");
+        return;
+    }
 
-      this->cameraMsgs[r].K[0] = fx;
-      this->cameraMsgs[r].K[2] = cx;
-      this->cameraMsgs[r].K[4] = fy;
-      this->cameraMsgs[r].K[5] = cy;
-      this->cameraMsgs[r].K[8] = 1.0;
+    // TODO make this only affect one robot if necessary
+    if((this->base_watchdog_timeout.toSec() > 0.0) &&
+            ((this->sim_time - this->base_last_cmd) >= this->base_watchdog_timeout))
+    {
+        for (size_t r = 0; r < this->positionmodels.size(); r++)
+            this->positionmodels[r]->SetSpeed(0.0, 0.0, 0.0);
+    }
 
-      this->cameraMsgs[r].R[0] = 1.0;
-      this->cameraMsgs[r].R[4] = 1.0;
-      this->cameraMsgs[r].R[8] = 1.0;
+    //loop on the robot models
+    for (size_t r = 0; r < this->robotmodels_.size(); ++r)
+    {
+        StageRobot const * robotmodel = this->robotmodels_[r];
 
-      this->cameraMsgs[r].P[0] = fx;
-      this->cameraMsgs[r].P[2] = cx;
-      this->cameraMsgs[r].P[5] = fy;
-      this->cameraMsgs[r].P[6] = cy;
-      this->cameraMsgs[r].P[10] = 1.0;
-      
-      this->camera_pubs_[r].publish(this->cameraMsgs[r]);                                    
+        //loop on the laser devices for the current robot
+        for (size_t s = 0; s < robotmodel->lasermodels.size(); ++s)
+        {
+            Stg::ModelRanger const* lasermodel = robotmodel->lasermodels[s];
+            const std::vector<Stg::ModelRanger::Sensor>& sensors = lasermodel->GetSensors();
 
-    }   
-     
-    
-  }
+            if( sensors.size() > 1 )
+                ROS_WARN( "ROS Stage currently supports rangers with 1 sensor only." );
 
-  this->clockMsg.clock = sim_time;
-  this->clock_pub_.publish(this->clockMsg);
+            // for now we access only the zeroth sensor of the ranger - good
+            // enough for most laser models that have a single beam origin
+            const Stg::ModelRanger::Sensor& sensor = sensors[0];
+
+            if( sensor.ranges.size() )
+            {
+                // Translate into ROS message format and publish
+                sensor_msgs::LaserScan msg;
+                msg.angle_min = -sensor.fov/2.0;
+                msg.angle_max = +sensor.fov/2.0;
+                msg.angle_increment = sensor.fov/(double)(sensor.sample_count-1);
+                msg.range_min = sensor.range.min;
+                msg.range_max = sensor.range.max;
+                msg.ranges.resize(sensor.ranges.size());
+                msg.intensities.resize(sensor.intensities.size());
+
+                for(unsigned int i = 0; i < sensor.ranges.size(); i++)
+                {
+                    msg.ranges[i] = sensor.ranges[i];
+                    msg.intensities[i] = (uint8_t)sensor.intensities[i];
+                }
+
+                if (robotmodel->lasermodels.size() > 1)
+                    msg.header.frame_id = mapName("base_laser_link", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                else
+                    msg.header.frame_id = mapName("base_laser_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+
+                msg.header.stamp = sim_time;
+                robotmodel->laser_pubs[s].publish(msg);
+            }
+
+            // Also publish the base->base_laser_link Tx.  This could eventually move
+            // into being retrieved from the param server as a static Tx.
+            Stg::Pose lp = lasermodel->GetPose();
+            tf::Quaternion laserQ;
+            laserQ.setRPY(0.0, 0.0, lp.a);
+            tf::Transform txLaser =  tf::Transform(laserQ, tf::Point(lp.x, lp.y, robotmodel->positionmodel->GetGeom().size.z + lp.z));
+
+            if (robotmodel->lasermodels.size() > 1)
+                tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
+                                                      mapName("base_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                      mapName("base_laser_link", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+            else
+                tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
+                                                      mapName("base_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                      mapName("base_laser_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+        }
+
+        //the position of the robot
+        //tf::Transform txIdentity(tf::createIdentityQuaternion(), tf::Point(0, 0, 0));
+        tf.sendTransform(tf::StampedTransform(tf::Transform::getIdentity(),
+                                              sim_time,
+                                              mapName("base_footprint", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                              mapName("base_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+
+        // Get latest odometry data
+        // Translate into ROS message format and publish
+        nav_msgs::Odometry odom_msg;
+        odom_msg.pose.pose.position.x = robotmodel->positionmodel->est_pose.x;
+        odom_msg.pose.pose.position.y = robotmodel->positionmodel->est_pose.y;
+        odom_msg.pose.pose.orientation = tf::createQuaternionMsgFromYaw(robotmodel->positionmodel->est_pose.a);
+        Stg::Velocity v = robotmodel->positionmodel->GetVelocity();
+        odom_msg.twist.twist.linear.x = v.x;
+        odom_msg.twist.twist.linear.y = v.y;
+        odom_msg.twist.twist.angular.z = v.a;
+
+        //@todo Publish stall on a separate topic when one becomes available
+        //this->odomMsgs[r].stall = this->positionmodels[r]->Stall();
+        //
+        odom_msg.header.frame_id = mapName("odom", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+        odom_msg.header.stamp = sim_time;
+
+        robotmodel->odom_pub.publish(odom_msg);
+
+        // broadcast odometry transform
+        tf::Quaternion odomQ;
+        tf::quaternionMsgToTF(odom_msg.pose.pose.orientation, odomQ);
+        tf::Transform txOdom(odomQ, tf::Point(odom_msg.pose.pose.position.x, odom_msg.pose.pose.position.y, 0.0));
+        tf.sendTransform(tf::StampedTransform(txOdom, sim_time,
+                                              mapName("odom", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                              mapName("base_footprint", r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+
+        // Also publish the ground truth pose and velocity
+        Stg::Pose gpose = robotmodel->positionmodel->GetGlobalPose();
+        tf::Quaternion q_gpose;
+        q_gpose.setRPY(0.0, 0.0, gpose.a);
+        tf::Transform gt(q_gpose, tf::Point(gpose.x, gpose.y, 0.0));
+        // Velocity is 0 by default and will be set only if there is previous pose and time delta>0
+        Stg::Velocity gvel(0,0,0,0);
+        if (this->base_last_globalpos.size()>r){
+            Stg::Pose prevpose = this->base_last_globalpos.at(r);
+            double dT = (this->sim_time-this->base_last_globalpos_time).toSec();
+            if (dT>0)
+                gvel = Stg::Velocity(
+                            (gpose.x - prevpose.x)/dT,
+                            (gpose.y - prevpose.y)/dT,
+                            (gpose.z - prevpose.z)/dT,
+                            Stg::normalize(gpose.a - prevpose.a)/dT
+                            );
+            this->base_last_globalpos.at(r) = gpose;
+        }else //There are no previous readings, adding current pose...
+            this->base_last_globalpos.push_back(gpose);
+
+        nav_msgs::Odometry ground_truth_msg;
+        ground_truth_msg.pose.pose.position.x     = gt.getOrigin().x();
+        ground_truth_msg.pose.pose.position.y     = gt.getOrigin().y();
+        ground_truth_msg.pose.pose.position.z     = gt.getOrigin().z();
+        ground_truth_msg.pose.pose.orientation.x  = gt.getRotation().x();
+        ground_truth_msg.pose.pose.orientation.y  = gt.getRotation().y();
+        ground_truth_msg.pose.pose.orientation.z  = gt.getRotation().z();
+        ground_truth_msg.pose.pose.orientation.w  = gt.getRotation().w();
+        ground_truth_msg.twist.twist.linear.x = gvel.x;
+        ground_truth_msg.twist.twist.linear.y = gvel.y;
+        ground_truth_msg.twist.twist.linear.z = gvel.z;
+        ground_truth_msg.twist.twist.angular.z = gvel.a;
+
+        ground_truth_msg.header.frame_id = mapName("odom", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+        ground_truth_msg.header.stamp = sim_time;
+
+        robotmodel->ground_truth_pub.publish(ground_truth_msg);
+
+        //cameras
+        for (size_t s = 0; s < robotmodel->cameramodels.size(); ++s)
+        {
+            Stg::ModelCamera* cameramodel = robotmodel->cameramodels[s];
+            // Get latest image data
+            // Translate into ROS message format and publish
+            if (robotmodel->image_pubs[s].getNumSubscribers() > 0 && cameramodel->FrameColor())
+            {
+                sensor_msgs::Image image_msg;
+
+                image_msg.height = cameramodel->getHeight();
+                image_msg.width = cameramodel->getWidth();
+                image_msg.encoding = "rgba8";
+                //this->imageMsgs[r].is_bigendian="";
+                image_msg.step = image_msg.width*4;
+                image_msg.data.resize(image_msg.width * image_msg.height * 4);
+
+                memcpy(&(image_msg.data[0]), cameramodel->FrameColor(), image_msg.width * image_msg.height * 4);
+
+                //invert the opengl weirdness
+                int height = image_msg.height - 1;
+                int linewidth = image_msg.width*4;
+
+                char* temp = new char[linewidth];
+                for (int y = 0; y < (height+1)/2; y++)
+                {
+                    memcpy(temp,&image_msg.data[y*linewidth],linewidth);
+                    memcpy(&(image_msg.data[y*linewidth]),&(image_msg.data[(height-y)*linewidth]),linewidth);
+                    memcpy(&(image_msg.data[(height-y)*linewidth]),temp,linewidth);
+                }
+
+                if (robotmodel->cameramodels.size() > 1)
+                    image_msg.header.frame_id = mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                else
+                    image_msg.header.frame_id = mapName("camera", r,static_cast<Stg::Model*>(robotmodel->positionmodel));
+                image_msg.header.stamp = sim_time;
+
+                robotmodel->image_pubs[s].publish(image_msg);
+            }
+
+            //Get latest depth data
+            //Translate into ROS message format and publish
+            //Skip if there are no subscribers
+            if (robotmodel->depth_pubs[s].getNumSubscribers()>0 && cameramodel->FrameDepth())
+            {
+                sensor_msgs::Image depth_msg;
+                depth_msg.height = cameramodel->getHeight();
+                depth_msg.width = cameramodel->getWidth();
+                depth_msg.encoding = this->isDepthCanonical?sensor_msgs::image_encodings::TYPE_32FC1:sensor_msgs::image_encodings::TYPE_16UC1;
+                //this->depthMsgs[r].is_bigendian="";
+                int sz = this->isDepthCanonical?sizeof(float):sizeof(uint16_t);
+                size_t len = depth_msg.width * depth_msg.height;
+                depth_msg.step = depth_msg.width * sz;
+                depth_msg.data.resize(len*sz);
+
+                //processing data according to REP118
+                if (this->isDepthCanonical){
+                    double nearClip = cameramodel->getCamera().nearClip();
+                    double farClip = cameramodel->getCamera().farClip();
+                    memcpy(&(depth_msg.data[0]),cameramodel->FrameDepth(),len*sz);
+                    float * data = (float*)&(depth_msg.data[0]);
+                    for (size_t i=0;i<len;++i)
+                        if(data[i]<=nearClip)
+                            data[i] = -INFINITY;
+                        else if(data[i]>=farClip)
+                            data[i] = INFINITY;
+                }
+                else{
+                    int nearClip = (int)(cameramodel->getCamera().nearClip() * 1000);
+                    int farClip = (int)(cameramodel->getCamera().farClip() * 1000);
+                    for (size_t i=0;i<len;++i){
+                        int v = (int)(cameramodel->FrameDepth()[i]*1000);
+                        if (v<=nearClip || v>=farClip) v = 0;
+                        ((uint16_t*)&(depth_msg.data[0]))[i] = (uint16_t) ((v<=nearClip || v>=farClip) ? 0 : v );
+                    }
+                }
+
+                //invert the opengl weirdness
+                int height = depth_msg.height - 1;
+                int linewidth = depth_msg.width*sz;
+
+                char* temp = new char[linewidth];
+                for (int y = 0; y < (height+1)/2; y++)
+                {
+                    memcpy(temp,&depth_msg.data[y*linewidth],linewidth);
+                    memcpy(&(depth_msg.data[y*linewidth]),&(depth_msg.data[(height-y)*linewidth]),linewidth);
+                    memcpy(&(depth_msg.data[(height-y)*linewidth]),temp,linewidth);
+                }
+
+                if (robotmodel->cameramodels.size() > 1)
+                    depth_msg.header.frame_id = mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                else
+                    depth_msg.header.frame_id = mapName("camera", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                depth_msg.header.stamp = sim_time;
+                robotmodel->depth_pubs[s].publish(depth_msg);
+            }
+
+            //sending camera's tf and info only if image or depth topics are subscribed to
+            if ((robotmodel->image_pubs[s].getNumSubscribers()>0 && cameramodel->FrameColor())
+                    || (robotmodel->depth_pubs[s].getNumSubscribers()>0 && cameramodel->FrameDepth()))
+            {
+
+                Stg::Pose lp = cameramodel->GetPose();
+                tf::Quaternion Q; Q.setRPY(
+                            (cameramodel->getCamera().pitch()*M_PI/180.0)-M_PI,
+                            0.0,
+                            lp.a+(cameramodel->getCamera().yaw()*M_PI/180.0) - robotmodel->positionmodel->GetPose().a
+                            );
+
+                tf::Transform tr =  tf::Transform(Q, tf::Point(lp.x, lp.y, robotmodel->positionmodel->GetGeom().size.z+lp.z));
+
+                if (robotmodel->cameramodels.size() > 1)
+                    tf.sendTransform(tf::StampedTransform(tr, sim_time,
+                                                          mapName("base_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                          mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                else
+                    tf.sendTransform(tf::StampedTransform(tr, sim_time,
+                                                          mapName("base_link", r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                          mapName("camera", r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+
+                sensor_msgs::CameraInfo camera_msg;
+                if (robotmodel->cameramodels.size() > 1)
+                    camera_msg.header.frame_id = mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                else
+                    camera_msg.header.frame_id = mapName("camera", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                camera_msg.header.stamp = sim_time;
+                camera_msg.height = cameramodel->getHeight();
+                camera_msg.width = cameramodel->getWidth();
+
+                double fx,fy,cx,cy;
+                cx = camera_msg.width / 2.0;
+                cy = camera_msg.height / 2.0;
+                double fovh = cameramodel->getCamera().horizFov()*M_PI/180.0;
+                double fovv = cameramodel->getCamera().vertFov()*M_PI/180.0;
+                //double fx_ = 1.43266615300557*this->cameramodels[r]->getWidth()/tan(fovh);
+                //double fy_ = 1.43266615300557*this->cameramodels[r]->getHeight()/tan(fovv);
+                fx = cameramodel->getWidth()/(2*tan(fovh/2));
+                fy = cameramodel->getHeight()/(2*tan(fovv/2));
+
+                //ROS_INFO("fx=%.4f,%.4f; fy=%.4f,%.4f", fx, fx_, fy, fy_);
+
+
+                camera_msg.D.resize(4, 0.0);
+
+                camera_msg.K[0] = fx;
+                camera_msg.K[2] = cx;
+                camera_msg.K[4] = fy;
+                camera_msg.K[5] = cy;
+                camera_msg.K[8] = 1.0;
+
+                camera_msg.R[0] = 1.0;
+                camera_msg.R[4] = 1.0;
+                camera_msg.R[8] = 1.0;
+
+                camera_msg.P[0] = fx;
+                camera_msg.P[2] = cx;
+                camera_msg.P[5] = fy;
+                camera_msg.P[6] = cy;
+                camera_msg.P[10] = 1.0;
+
+                robotmodel->camera_pubs[s].publish(camera_msg);
+
+            }
+
+        }
+    }
+
+    this->base_last_globalpos_time = this->sim_time;
+    rosgraph_msgs::Clock clock_msg;
+    clock_msg.clock = sim_time;
+    this->clock_pub_.publish(clock_msg);
 }
 
 int 
 main(int argc, char** argv)
 { 
-  if( argc < 2 )
-  {
-    puts(USAGE);
-    exit(-1);
-  }
-
-  ros::init(argc, argv, "stageros");
-
-  bool gui = true;
-  bool use_model_names = false;
-  for(int i=0;i<(argc-1);i++)
-  {
-    if(!strcmp(argv[i], "-g"))
-      gui = false;
-    if(!strcmp(argv[i], "-u"))
-    	use_model_names = true;
-  }
-
-  StageNode sn(argc-1,argv,gui,argv[argc-1], use_model_names);
-
-  if(sn.SubscribeModels() != 0)
-    exit(-1);
-
-  boost::thread t = boost::thread(boost::bind(&ros::spin));
-
-  // New in Stage 4.1.1: must Start() the world.
-  sn.world->Start();
-
-  // TODO: get rid of this fixed-duration sleep, using some Stage builtin
-  // PauseUntilNextUpdate() functionality.
-  ros::WallRate r(10.0);
-  while(ros::ok() && !sn.world->TestQuit())
-  {
-    if(gui)
-      Fl::wait(r.expectedCycleTime().toSec());
-    else
+    if( argc < 2 )
     {
-      sn.UpdateWorld();
-      r.sleep();
+        puts(USAGE);
+        exit(-1);
     }
-  }
-  t.join();
 
-  exit(0);
+    ros::init(argc, argv, "stageros");
+
+    bool gui = true;
+    bool use_model_names = false;
+    for(int i=0;i<(argc-1);i++)
+    {
+        if(!strcmp(argv[i], "-g"))
+            gui = false;
+        if(!strcmp(argv[i], "-u"))
+            use_model_names = true;
+    }
+
+    StageNode sn(argc-1,argv,gui,argv[argc-1], use_model_names);
+
+    if(sn.SubscribeModels() != 0)
+        exit(-1);
+
+    boost::thread t = boost::thread(boost::bind(&ros::spin));
+
+    // New in Stage 4.1.1: must Start() the world.
+    sn.world->Start();
+
+    // TODO: get rid of this fixed-duration sleep, using some Stage builtin
+    // PauseUntilNextUpdate() functionality.
+    ros::WallRate r(10.0);
+    while(ros::ok() && !sn.world->TestQuit())
+    {
+        if(gui)
+            Fl::wait(r.expectedCycleTime().toSec());
+        else
+        {
+            sn.UpdateWorld();
+            r.sleep();
+        }
+    }
+    t.join();
+
+    exit(0);
 }
 

--- a/world/willow-four-erratics-multisensor.world
+++ b/world/willow-four-erratics-multisensor.world
@@ -1,0 +1,87 @@
+define block model
+(
+  size [0.5 0.5 0.5]
+  gui_nose 0
+)
+
+define topurg ranger
+(
+	sensor( 			
+    range [ 0.0  30.0 ]
+    fov 270.25
+   samples 1081
+  )
+
+  # generic model properties
+  color "black"
+  size [ 0.05 0.05 0.1 ]
+)
+
+define mycamera camera
+(
+	range [ 0.2 8.0 ]
+	resolution [ 100 100 ]
+	fov [ 70 40 ]
+	pantilt [ 0 0 ]
+	alwayson 1
+)
+
+define erratic position
+(
+  #size [0.415 0.392 0.25]
+  size [0.35 0.35 0.25]
+  origin [-0.05 0 0 0]
+  gui_nose 1
+  drive "diff"
+  topurg(pose [ 0.050 0.000 0 0.000 ])
+  topurg(pose [ -0.050 0.000 0 180.000 ])
+  mycamera(pose [ 0 0 0 90.0 ])
+  mycamera(pose [ 0 0 0 -90.0 ])
+)
+
+define floorplan model
+(
+  # sombre, sensible, artistic
+  color "gray30"
+
+  # most maps will need a bounding box
+  boundary 1
+
+  gui_nose 0
+  gui_grid 0
+
+  gui_outline 0
+  gripper_return 0
+  fiducial_return 0
+  laser_return 1
+)
+
+# set the resolution of the underlying raytrace model in meters
+resolution 0.02
+
+interval_sim 100  # simulation timestep in milliseconds
+
+
+window
+( 
+  size [ 745.000 448.000 ] 
+
+  rotate [ 0.000 -1.560 ]
+  scale 28.806 
+)
+
+# load an environment bitmap
+floorplan
+( 
+  name "willow"
+  bitmap "willow-full.pgm"
+  size [54.0 58.7 0.5]
+  pose [ -29.350 27.000 0 90.000 ]
+)
+
+# throw in two robots
+erratic( pose [ -11.277 23.266 0 180.000 ] name "era" color "blue")
+erratic( pose [ -13.277 22.266 0 180.000 ] name "era2" color "blue")
+erratic( pose [ -13.277 23.266 0 180.000 ] name "era3" color "blue")
+erratic( pose [ -11.277 22.266 0 180.000 ] name "era4" color "blue")
+block( pose [ -13.924 25.020 0 180.000 ] color "red")


### PR DESCRIPTION
I have added support for having multiple sensors (camera and laser scan) per robot.
The names of the topics of the devices and the frame are numerated to make them unique.
Here is an example of the list of topics with two robots with two laser scans and two cameras each.

pablo@xidri:~$ rostopic list
/clock
/robot_0/base_pose_ground_truth
/robot_0/base_scan_0
/robot_0/base_scan_1
/robot_0/camera_info_0
/robot_0/camera_info_1
/robot_0/cmd_vel
/robot_0/depth_0
/robot_0/depth_1
/robot_0/image_0
/robot_0/image_1
/robot_0/odom
/robot_1/base_pose_ground_truth
/robot_1/base_scan_0
/robot_1/base_scan_1
/robot_1/camera_info_0
/robot_1/camera_info_1
/robot_1/cmd_vel
/robot_1/depth_0
/robot_1/depth_1
/robot_1/image_0
/robot_1/image_1
/robot_1/odom
