### PR TITLE
Fix Catkin testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,4 +61,6 @@ install(DIRECTORY world
 
 ## Tests
 
-add_rostest(test/hztest.xml)
+if(CATKIN_ENABLE_TESTING)
+	add_rostest(test/hztest.xml)
+endif()


### PR DESCRIPTION
Hi,

Here is a small fix to avoid catkin complaining about gtest when testing is disabled.

Regards,