### PR TITLE
add reset_positions service to stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED
     roscpp
     sensor_msgs
     std_msgs
+    std_srvs
     tf
 )
 

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>stage</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
 
   <run_depend>boost</run_depend>
@@ -35,5 +36,6 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>stage</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
 </package>


### PR DESCRIPTION
This change adds the service call /reset_positions to reset the robots in stage to the original positions when the world was started. This can be handy if you want to quickly rerun things and do not want to relaunch stage every time. 