### PR TITLE
Configure .world file when starting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ endif()
 
 install(PROGRAMS scripts/upgrade-world.sh
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(PROGRAMS scripts/rosparam_instantiate.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(TARGETS stageros
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/scripts/rosparam_instantiate.py
+++ b/scripts/rosparam_instantiate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+import rospy
+import sys
+
+def instantiate_rosparams(world_str_in, rosparam_objs):
+	"""
+	Include this function if you want to embed this script's functionality in your own script.
+	"""
+	world_str_out = world_str_in + '\n\n# Additional rosparam objects\n\n'
+
+	for obj_name, obj_props in rosparam_objs.items():
+		try:
+			obj_str = obj_props['model_type'] + '\n(\n'
+			obj_str += '    name "%s"\n' % str(obj_name)
+			for prop, val in obj_props.items():
+				obj_str += '    %s ' % str(prop)
+				if isinstance(val, int) or isinstance(val, float):
+					obj_str += str(val)
+				elif isinstance(val, list):
+					obj_str += '[ %s ]' % ' '.join(map(str, val))
+				else:
+					obj_str += '"%s"' % str(val)
+				obj_str += '\n'
+			obj_str += ')\n\n'
+			world_str_out += obj_str
+
+		except Exception as e:
+			rospy.logwarn('Skip inserting "%s" into stage world:\n%s' % (str(obj_name), str(e)))
+
+	return world_str_out
+
+
+if __name__ == '__main__':
+
+	rospy.init_node('stage_rosparam_instantiate')
+
+	if len(sys.argv) != 4:
+		rospy.logwarn('''Failed to instantiate objects in stage world: Wrong number of arguments!
+Usage: rosparam_instantiate.py worldfile_in rosparam_ns worldfile_out
+ - worldfile_in:  Path to initial .world file.
+ - rosparam_ns:   Namespace which contains the objects to be instantiated.
+ - worldfile_out: Path to resulting .world file (loaded by stage).''')
+
+	else:
+		worldfile_in = sys.argv[1]
+		rosparam_ns = sys.argv[2]
+		worldfile_out = sys.argv[-1]
+
+		world_str_out = None
+		try:
+			world_str_in = ""
+			with open(worldfile_in, 'r') as f:
+				world_str_in = f.read()
+
+			rosparam_objs = rospy.get_param(rosparam_ns)
+			if not isinstance(rosparam_objs, dict):
+				raise TypeError(rosparam_objs.__class__)
+
+			# do the work...
+			world_str_out = instantiate_rosparams(world_str_in, rosparam_objs)
+
+		except IOError as e:
+			rospy.logerr('Unable to load initial .world file for stage:\n%s' % str(e))
+		except KeyError as e:
+			rospy.logerr('Unable to access rosparam for stage:\nMissing key: %s' % str(e))
+		except TypeError as e:
+			rospy.logerr("Type mismatch of rosparam for stage:\nParam '%s' is %s, but should be a dictionary/namespace." % (rosparam_ns, str(e)))
+
+		if world_str_out is not None:
+			header_label = '# AUTO-GENERATED FILE by rosparam_instantiate.py'
+			header_args = '# args: ' + ' '.join(sys.argv[1:])
+			header_border = '#' * (max(len(header_label), len(header_args)) + 1)
+			header = '\n'.join([header_border, header_label, header_args, header_border, '\n'])
+
+			try:
+				with open(worldfile_out, 'w') as f:
+					f.write(header)
+					f.write(world_str_out)
+
+			except IOError as e:
+				rospy.logerr('Unable to write resulting .world file for stage:\n%s' % str(e))

--- a/scripts/rosparam_instantiate.py
+++ b/scripts/rosparam_instantiate.py
@@ -13,6 +13,7 @@ def instantiate_rosparams(world_str_in, rosparam_objs):
 			obj_str = obj_props['model_type'] + '\n(\n'
 			obj_str += '    name "%s"\n' % str(obj_name)
 			for prop, val in obj_props.items():
+				if str(prop) == 'model_type': continue
 				obj_str += '    %s ' % str(prop)
 				if isinstance(val, int) or isinstance(val, float):
 					obj_str += str(val)


### PR DESCRIPTION
This might be of interest for others as well. It would be nicer if we could just pass a .world string instead of a file to stage, but I wanted to touch as little as possible.

I needed a way to dynamically configure a .world file when starting stage from a .launch file, e.g., spawn a parametrizable number of robots (in principle, idea similar to xacro for urdf). Since I didn't find a way, I added the following new option:

`-c <script> [args] <worldfile>`
`<script>` is a custom script to configure the .world file (see below)
`[args]` are optional arguments to the script (all args following -c will be passed, so -u or -g need to preceed -c)
`<worldfile>` as usual, the used .world file stays the last argument and will be as well passed to the script as target

An arbitrary custom script can be used for configuration as long as it writes its result to `<worldfile>`. For convenience and reference, I added the script `rosparam_instantiate.py` to this PR:

```
Usage: rosparam_instantiate.py worldfile_in rosparam_ns worldfile_out
 - worldfile_in:  Path to initial .world file.
 - rosparam_ns:   Namespace which contains the objects to be instantiated.
 - worldfile_out: Path to resulting .world file (loaded by stage).
```

It accepts a rosparam namespace and instantiates all objects into the world `worldfile_in`. It can be used in a launchfile like the following example:

```
<arg name="test_color" value="red" />
<rosparam ns="/stage_objs" subst_value="True">
test:
    model_type: block
    pose: [0,1,0,0]
    color: $(arg test_color)
</rosparam>

<node pkg="stage_ros" name="stageros" type="stageros" args="-c $(find stage_ros)/scripts/rosparam_instantiate.py $(find stage_ros)/world/intense.world /stage_objs $(find stage_ros)/world/tmp.world"/>
```

which will spawn the following object:

```
block
(
    name "test"
    color "red"
    pose [ 0 1 0 0 ]
)
```

Note the following two aspects:
- As shown above, it is possible to use roslaunch's substitution args to dynamically set values.
- Since a namespace is expected instead of a param of type list, multiple different launchfiles can spawn objects into the same namespace. Just make sure the object names are unique, otherwise one will overwrite the other. If required, $(anon name) can help to keep names unique.
