### PR TITLE
Odom child frame is filled

### DIFF
--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -523,6 +523,7 @@ StageNode::WorldCallback()
         //
         odom_msg.header.frame_id = mapName("odom", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
         odom_msg.header.stamp = sim_time;
+        odom_msg.child_frame_id = std::string("base_footprint");
 
         robotmodel->odom_pub.publish(odom_msg);
 


### PR DESCRIPTION
__Issue__: when publishing to `/odom` topic, the odom_msg's `child_frame_id` field is not filled. This should always be `base_footprint` (or `base_link`, but they are identical in this context). 

__Solution:__ fill the odom_msg.child_frame_id field with `base_footprint`. Leaving it empty can lead to issues relating odom to the rest of the tf tree of a robot.