### PR TITLE
Multi-sensors (laser and camera) frame_id renaming and TF publish control

### DIFF
--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -143,6 +143,10 @@ private:
 
     std::vector<std::string> camera_frame_ids_;
 
+    std::vector<bool> publish_laser_tfs_;
+
+    std::vector<bool> publish_camera_tfs_;
+
     // Current simulation time
     ros::Time sim_time;
     
@@ -306,6 +310,12 @@ StageNode::StageNode(int argc, char** argv, bool gui, const char* fname, bool us
 
     if(!localn.getParam("camera_frame_ids", this->camera_frame_ids_))
         this->camera_frame_ids_.push_back("camera");
+
+    if(!localn.getParam("publish_laser_tfs", this->publish_laser_tfs_))
+        this->publish_laser_tfs_.push_back(true);
+
+    if(!localn.getParam("publish_camera_tfs", this->publish_camera_tfs_))
+        this->publish_camera_tfs_.push_back(true);
 
     if(!localn.getParam("is_depth_canonical", isDepthCanonical))
         isDepthCanonical = true;
@@ -525,19 +535,25 @@ StageNode::WorldCallback()
             if (robotmodel->lasermodels.size() > 1){
               if (robotmodel->lasermodels.size() != this->laser_frame_ids_.size()){
                 ROS_INFO("Size of laser_frame_ids mismatches the number of lasers, applying default frame id naming");
-                tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
-                                                      mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
-                                                      mapName(this->laser_frame_ids_[0].c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                if(publish_laser_tfs_[0]){
+                  tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
+                                                        mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                        mapName(this->laser_frame_ids_[0].c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                }
               }else {
-                tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
-                                                      mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
-                                                      this->laser_frame_ids_[s]));
+                if(publish_laser_tfs_[s]){
+                  tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
+                                                        mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                        this->laser_frame_ids_[s]));
+                }
               }
             }
             else
+              if(publish_laser_tfs_[0]){
                 tf.sendTransform(tf::StampedTransform(txLaser, sim_time,
                                                       mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
                                                       mapName(this->laser_frame_ids_[0].c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+              }
         }
 
         //the position of the robot
@@ -738,19 +754,25 @@ StageNode::WorldCallback()
                 if (robotmodel->cameramodels.size() > 1){
                     if (robotmodel->cameramodels.size() != this->camera_frame_ids_.size()){
                       ROS_INFO("Size of camera_frame_ids mismatches the number of cameras, applying default frame id naming");
-                      tf.sendTransform(tf::StampedTransform(tr, sim_time,
-                                                            mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
-                                                            mapName(this->camera_frame_ids_[0].c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                      if(publish_camera_tfs_[0]){
+                        tf.sendTransform(tf::StampedTransform(tr, sim_time,
+                                                              mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                              mapName(this->camera_frame_ids_[0].c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                      }
                     }else {
-                      tf.sendTransform(tf::StampedTransform(tr, sim_time,
-                                                            mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
-                                                            this->camera_frame_ids_[s].c_str()));
+                      if(publish_camera_tfs_[s]){
+                        tf.sendTransform(tf::StampedTransform(tr, sim_time,
+                                                              mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
+                                                              this->camera_frame_ids_[s].c_str()));
+                      }
                     }
                 }
                 else
+                  if(publish_camera_tfs_[0]){
                     tf.sendTransform(tf::StampedTransform(tr, sim_time,
                                                           mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
                                                           mapName(this->camera_frame_ids_[0].c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                  }
 
                 sensor_msgs::CameraInfo camera_msg;
                 if (robotmodel->cameramodels.size() > 1){

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -470,7 +470,7 @@ StageNode::WorldCallback()
                 msg.angle_max = +sensor.fov/2.0;
                 msg.angle_increment = sensor.fov/(double)(sensor.sample_count-1);
                 msg.range_min = sensor.range.min;
-                msg.range_max = sensor.range.max;
+                msg.range_max = sensor.range.max - 0.1;
                 msg.ranges.resize(sensor.ranges.size());
                 msg.intensities.resize(sensor.intensities.size());
 

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -141,6 +141,8 @@ private:
 
     std::string base_laser_frame_id_;
 
+    std::string base_camera_frame_id_;
+
     // Current simulation time
     ros::Time sim_time;
     
@@ -301,6 +303,9 @@ StageNode::StageNode(int argc, char** argv, bool gui, const char* fname, bool us
 
     if(!localn.getParam("base_laser_frame_id", this->base_laser_frame_id_))
         this->base_laser_frame_id_="base_laser_link";
+
+    if(!localn.getParam("base_camera_frame_id", this->base_camera_frame_id_))
+        this->base_camera_frame_id_="camera";
 
     if(!localn.getParam("is_depth_canonical", isDepthCanonical))
         isDepthCanonical = true;
@@ -625,9 +630,9 @@ StageNode::WorldCallback()
                 }
 
                 if (robotmodel->cameramodels.size() > 1)
-                    image_msg.header.frame_id = mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                    image_msg.header.frame_id = mapName(this->base_camera_frame_id_.c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
                 else
-                    image_msg.header.frame_id = mapName("camera", r,static_cast<Stg::Model*>(robotmodel->positionmodel));
+                    image_msg.header.frame_id = mapName(this->base_camera_frame_id_.c_str(), r,static_cast<Stg::Model*>(robotmodel->positionmodel));
                 image_msg.header.stamp = sim_time;
 
                 robotmodel->image_pubs[s].publish(image_msg);
@@ -683,9 +688,9 @@ StageNode::WorldCallback()
                 }
 
                 if (robotmodel->cameramodels.size() > 1)
-                    depth_msg.header.frame_id = mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                    depth_msg.header.frame_id = mapName(this->base_camera_frame_id_.c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
                 else
-                    depth_msg.header.frame_id = mapName("camera", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                    depth_msg.header.frame_id = mapName(this->base_camera_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel));
                 depth_msg.header.stamp = sim_time;
                 robotmodel->depth_pubs[s].publish(depth_msg);
             }
@@ -707,17 +712,17 @@ StageNode::WorldCallback()
                 if (robotmodel->cameramodels.size() > 1)
                     tf.sendTransform(tf::StampedTransform(tr, sim_time,
                                                           mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
-                                                          mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                                                          mapName(this->base_camera_frame_id_.c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel))));
                 else
                     tf.sendTransform(tf::StampedTransform(tr, sim_time,
                                                           mapName(this->base_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel)),
-                                                          mapName("camera", r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
+                                                          mapName(this->base_camera_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel))));
 
                 sensor_msgs::CameraInfo camera_msg;
                 if (robotmodel->cameramodels.size() > 1)
-                    camera_msg.header.frame_id = mapName("camera", r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                    camera_msg.header.frame_id = mapName(this->base_camera_frame_id_.c_str(), r, s, static_cast<Stg::Model*>(robotmodel->positionmodel));
                 else
-                    camera_msg.header.frame_id = mapName("camera", r, static_cast<Stg::Model*>(robotmodel->positionmodel));
+                    camera_msg.header.frame_id = mapName(this->base_camera_frame_id_.c_str(), r, static_cast<Stg::Model*>(robotmodel->positionmodel));
                 camera_msg.header.stamp = sim_time;
                 camera_msg.height = cameramodel->getHeight();
                 camera_msg.width = cameramodel->getWidth();


### PR DESCRIPTION
Taking inspiration from https://github.com/ros-simulation/stage_ros/pull/38 and https://github.com/ros-simulation/stage_ros/pull/41, this PR enables 2 things:

- Renaming  all tf frames : odom, base_link, base_footprint, laser(s) and camera(s).
- Disabling the publication of the TF transforms of the sensors with per sensor control.

This is done through parameters and array of parameters. Default (old) behavior should be ensured in case the parameters are not set. Below an example launch file:

```
<launch>
  <param name="use_sim_time" value="true"/>
  <node pkg="stage_ros" type="stageros" name="stageros" args="/tmp/stage_world.world">

  <param name="odom_frame_id" value="odom"/>
  <param name="base_link_frame_id" value="base_link"/>
  <param name="base_footprint_frame_id" value="base_footprint"/>

  <rosparam param="laser_frame_ids">['front_laser_link', 'back_laser_link']</rosparam>
  <rosparam param="camera_frame_ids">['camera_bottom_front_link', 'camera_top_front_link']</rosparam>

  <rosparam param="publish_laser_tfs">[false, true]</rosparam>
  <rosparam param="publish_camera_tfs">[true, false]</rosparam>


  <!-- sensor topics remaping -->
  <remap from="base_scan_0" to="scan_front"/>
  <remap from="base_scan_1" to="scan_back"/>

  <remap from="image_0" to="camera_bottom_front/image_raw"/>
  <remap from="camera_info_0" to="camera_bottom_front/camera_info"/>

  <remap from="image_1" to="camera_top_front_link/image_raw"/>
  <remap from="camera_info_1" to="camera_top_front_link/camera_info"/>
  </node>
</launch>
```