### PR TITLE
Imported queue library on python3

### DIFF
--- a/test/intensity_test.py
+++ b/test/intensity_test.py
@@ -3,7 +3,10 @@
 import unittest
 import rospy
 import time
-import Queue as queue
+try:
+    import Queue as queue
+except ImportError:
+    import queue
 from sensor_msgs.msg import LaserScan
 
 PKG = "stage_ros"


### PR DESCRIPTION
import queue is lowercase `q` in Python 3.

Signed-off-by: ahcorde <ahcorde@gmail.com>