### PR TITLE
ros interface for ModelightIndicators on stage and some fixes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-find_package(stage REQUIRED)
+find_package(stage REQUIRED PATHS /home/scifiswapnil/stage-buildqcc/)
 
 include_directories(
   ${catkin_INCLUDE_DIRS}

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -40,6 +40,7 @@
 
 // roscpp
 #include <ros/ros.h>
+// #include <std_msgs/Bool.h>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <sensor_msgs/LaserScan.h>
@@ -189,11 +190,11 @@ StageNode::mapName(const char *name, size_t robotID, Stg::Model* mod) const
 
         if ((found==std::string::npos) && umn)
         {
-            snprintf(buf, sizeof(buf), "/%s/%s", ((Stg::Ancestor *) mod)->Token(), name);
+            snprintf(buf, sizeof(buf), "%s/%s", ((Stg::Ancestor *) mod)->Token(), name);
         }
         else
         {
-            snprintf(buf, sizeof(buf), "/robot_%u/%s", (unsigned int)robotID, name);
+            snprintf(buf, sizeof(buf), "robot_%u/%s", (unsigned int)robotID, name);
         }
 
         return buf;
@@ -215,11 +216,11 @@ StageNode::mapName(const char *name, size_t robotID, size_t deviceID, Stg::Model
 
         if ((found==std::string::npos) && umn)
         {
-            snprintf(buf, sizeof(buf), "/%s/%s_%u", ((Stg::Ancestor *) mod)->Token(), name, (unsigned int)deviceID);
+            snprintf(buf, sizeof(buf), "%s/%s_%u", ((Stg::Ancestor *) mod)->Token(), name, (unsigned int)deviceID);
         }
         else
         {
-            snprintf(buf, sizeof(buf), "/robot_%u/%s_%u", (unsigned int)robotID, name, (unsigned int)deviceID);
+            snprintf(buf, sizeof(buf), "robot_%u/%s_%u", (unsigned int)robotID, name, (unsigned int)deviceID);
         }
 
         return buf;
@@ -227,7 +228,7 @@ StageNode::mapName(const char *name, size_t robotID, size_t deviceID, Stg::Model
     else
     {
         static char buf[100];
-        snprintf(buf, sizeof(buf), "/%s_%u", name, (unsigned int)deviceID);
+        snprintf(buf, sizeof(buf), "%s_%u", name, (unsigned int)deviceID);
         return buf;
     }
 }

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -40,7 +40,6 @@
 
 // roscpp
 #include <ros/ros.h>
-// #include <std_msgs/Bool.h>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <sensor_msgs/LaserScan.h>
@@ -49,7 +48,7 @@
 #include <sensor_msgs/CameraInfo.h>
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/Twist.h>
-#include <std_msgs/Float64.h>
+#include <std_msgs/Int8.h>
 #include <rosgraph_msgs/Clock.h>
 
 #include <std_srvs/Empty.h>
@@ -167,7 +166,7 @@ public:
 
     // Message callback for a MsgBaseVel message, which set velocities.
     void cmdvelReceived(int idx, const boost::shared_ptr<geometry_msgs::Twist const>& msg);
-    void lightReceived(int idx, const boost::shared_ptr<std_msgs::Float64 const>& msg);
+    void lightReceived(int idx, const boost::shared_ptr<std_msgs::Int8 const>& msg);
 
     // Service callback for soft reset
     bool cb_reset_srv(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
@@ -273,7 +272,7 @@ StageNode::cb_reset_srv(std_srvs::Empty::Request& request, std_srvs::Empty::Resp
 
 
 void
-StageNode::lightReceived(int idx, const boost::shared_ptr<std_msgs::Float64 const>& msg)
+StageNode::lightReceived(int idx, const boost::shared_ptr<std_msgs::Int8 const>& msg)
 {
     boost::mutex::scoped_lock lock(msg_lock);
     this->lightmodels[idx]->SetState(msg->data) ;
@@ -405,7 +404,7 @@ StageNode::SubscribeModels()
 
         for (size_t s = 0;  s < new_robot->lasermodels.size(); ++s)
         {
-            new_robot->light_subs.push_back(n_.subscribe<std_msgs::Float64>(mapName(LIGHTS, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, boost::bind(&StageNode::lightReceived, this, r, _1)));
+            new_robot->light_subs.push_back(n_.subscribe<std_msgs::Int8>(mapName(LIGHTS, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, boost::bind(&StageNode::lightReceived, this, r, _1)));
         }
 
         for (size_t s = 0;  s < new_robot->lasermodels.size(); ++s)

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -48,6 +48,7 @@
 #include <sensor_msgs/CameraInfo.h>
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/Twist.h>
+#include <std_msgs/Float64.h>
 #include <rosgraph_msgs/Clock.h>
 
 #include <std_srvs/Empty.h>
@@ -62,6 +63,7 @@
 #define BASE_SCAN "base_scan"
 #define BASE_POSE_GROUND_TRUTH "base_pose_ground_truth"
 #define CMD_VEL "cmd_vel"
+#define LIGHTS "light"
 
 // Our node
 class StageNode
@@ -78,6 +80,7 @@ private:
     std::vector<Stg::ModelCamera *> cameramodels;
     std::vector<Stg::ModelRanger *> lasermodels;
     std::vector<Stg::ModelPosition *> positionmodels;
+    std::vector<Stg::ModelLightIndicator *> lightmodels; 
 
     //a structure representing a robot inthe simulator
     struct StageRobot
@@ -86,6 +89,7 @@ private:
         Stg::ModelPosition* positionmodel; //one position
         std::vector<Stg::ModelCamera *> cameramodels; //multiple cameras per position
         std::vector<Stg::ModelRanger *> lasermodels; //multiple rangers per position
+        std::vector<Stg::ModelLightIndicator *> lightmodels; //multiple lights per position
 
         //ros publishers
         ros::Publisher odom_pub; //one odom
@@ -94,8 +98,9 @@ private:
         std::vector<ros::Publisher> image_pubs; //multiple images
         std::vector<ros::Publisher> depth_pubs; //multiple depths
         std::vector<ros::Publisher> camera_pubs; //multiple cameras
-        std::vector<ros::Publisher> laser_pubs; //multiple lasers
-
+        std::vector<ros::Publisher> laser_pubs; //multiple light
+        
+        std::vector<ros::Subscriber> light_subs; //multiple lasers
         ros::Subscriber cmdvel_sub; //one cmd_vel subscriber
     };
 
@@ -161,6 +166,7 @@ public:
 
     // Message callback for a MsgBaseVel message, which set velocities.
     void cmdvelReceived(int idx, const boost::shared_ptr<geometry_msgs::Twist const>& msg);
+    void lightReceived(int idx, const boost::shared_ptr<std_msgs::Float64 const>& msg);
 
     // Service callback for soft reset
     bool cb_reset_srv(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
@@ -234,6 +240,11 @@ StageNode::ghfunc(Stg::Model* mod, StageNode* node)
   if (dynamic_cast<Stg::ModelRanger *>(mod)) {
      node->lasermodels.push_back(dynamic_cast<Stg::ModelRanger *>(mod));
   }
+
+  if (dynamic_cast<Stg::ModelLightIndicator *>(mod)) {
+     node->lightmodels.push_back(dynamic_cast<Stg::ModelLightIndicator *>(mod));
+  }
+
   if (dynamic_cast<Stg::ModelPosition *>(mod)) {
      Stg::ModelPosition * p = dynamic_cast<Stg::ModelPosition *>(mod);
       // remember initial poses
@@ -260,6 +271,12 @@ StageNode::cb_reset_srv(std_srvs::Empty::Request& request, std_srvs::Empty::Resp
 }
 
 
+void
+StageNode::lightReceived(int idx, const boost::shared_ptr<std_msgs::Float64 const>& msg)
+{
+    boost::mutex::scoped_lock lock(msg_lock);
+    this->lightmodels[idx]->SetState(msg->data) ;
+}
 
 void
 StageNode::cmdvelReceived(int idx, const boost::shared_ptr<geometry_msgs::Twist const>& msg)
@@ -363,15 +380,32 @@ StageNode::SubscribeModels()
             }
         }
 
+        for (size_t s = 0; s < this->lightmodels.size(); s++)
+        {
+            if (this->lightmodels[s] and this->lightmodels[s]->Parent() == new_robot->positionmodel)
+            {
+                new_robot->lightmodels.push_back(this->lightmodels[s]);
+                this->lightmodels[s]->Subscribe();
+
+		ROS_INFO( "subscribed to Stage light model \"%s\"", this->lightmodels[s]->Token() ); 
+            }
+        }
+
 	// TODO - print the topic names nicely as well
-        ROS_INFO("Robot %s provided %lu rangers and %lu cameras",
+        ROS_INFO("Robot %s provided %lu rangers %lu lights  and %lu cameras",
 		 new_robot->positionmodel->Token(),
 		 new_robot->lasermodels.size(),
+         new_robot->lightmodels.size(),
 		 new_robot->cameramodels.size() );
 
         new_robot->odom_pub = n_.advertise<nav_msgs::Odometry>(mapName(ODOM, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10);
         new_robot->ground_truth_pub = n_.advertise<nav_msgs::Odometry>(mapName(BASE_POSE_GROUND_TRUTH, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10);
         new_robot->cmdvel_sub = n_.subscribe<geometry_msgs::Twist>(mapName(CMD_VEL, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, boost::bind(&StageNode::cmdvelReceived, this, r, _1));
+
+        for (size_t s = 0;  s < new_robot->lasermodels.size(); ++s)
+        {
+            new_robot->light_subs.push_back(n_.subscribe<std_msgs::Float64>(mapName(LIGHTS, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, boost::bind(&StageNode::lightReceived, this, r, _1)));
+        }
 
         for (size_t s = 0;  s < new_robot->lasermodels.size(); ++s)
         {
@@ -419,7 +453,7 @@ StageNode::UpdateWorld()
 {
     return this->world->UpdateAll();
 }
-
+bool global_state = true;
 void
 StageNode::WorldCallback()
 {
@@ -452,7 +486,6 @@ StageNode::WorldCallback()
     for (size_t r = 0; r < this->robotmodels_.size(); ++r)
     {
         StageRobot const * robotmodel = this->robotmodels_[r];
-
         //loop on the laser devices for the current robot
         for (size_t s = 0; s < robotmodel->lasermodels.size(); ++s)
         {

--- a/world/willow-four-erratics.world
+++ b/world/willow-four-erratics.world
@@ -4,6 +4,13 @@ define block model
   gui_nose 0
 )
 
+define light lightindicator
+(
+# generic model properties
+size [0.03 0.03 0.03]
+color "red"
+)
+
 define topurg ranger
 (
 	sensor( 			
@@ -24,6 +31,7 @@ define erratic position
   origin [-0.05 0 0 0]
   gui_nose 1
   drive "diff"
+  light()
   topurg(pose [ 0.050 0.000 0 0.000 ])
 )
 


### PR DESCRIPTION
Updates : 
* parameterised the gui and use_model_names parameters 
* ros topic interface for ModelLightIndicators
* remove "/" at start of frame names, melodic update
* updated a example world with ligh indicators 

![light](https://user-images.githubusercontent.com/5753164/80813342-7e3f3800-8be7-11ea-8aeb-640addb21052.gif)
