### PR TITLE
[ROS-O] Modernize code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(stage_ros)
 
 find_package(catkin REQUIRED

--- a/src/stageros.cpp
+++ b/src/stageros.cpp
@@ -362,7 +362,8 @@ StageNode::SubscribeModels()
 
         new_robot->odom_pub = n_.advertise<nav_msgs::Odometry>(mapName(ODOM, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10);
         new_robot->ground_truth_pub = n_.advertise<nav_msgs::Odometry>(mapName(BASE_POSE_GROUND_TRUTH, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10);
-        new_robot->cmdvel_sub = n_.subscribe<geometry_msgs::Twist>(mapName(CMD_VEL, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, boost::bind(&StageNode::cmdvelReceived, this, r, _1));
+        new_robot->cmdvel_sub = n_.subscribe<geometry_msgs::Twist>(mapName(CMD_VEL, r, static_cast<Stg::Model*>(new_robot->positionmodel)), 10, 
+                                                                   boost::bind(&StageNode::cmdvelReceived, this, r, boost::placeholders::_1));
 
         for (size_t s = 0;  s < new_robot->lasermodels.size(); ++s)
         {


### PR DESCRIPTION
- cmake_minimum_required 3.10.2 (recommendation for Noetic)
- Explicitly use `boost::placeholders::_1` (required for boost >= 1.73)